### PR TITLE
Implement MySQL persistence

### DIFF
--- a/client/js/NotaCornell.js
+++ b/client/js/NotaCornell.js
@@ -17,23 +17,33 @@ tinymce.init({
   menubar: false,
 });
 
-function guardarTodo() {
-  // Se crea el objeto JSON con todas las secciones
-  const quillTodo = {
-    keywords: quillKeywords.getContents(),
-    notas: quillNotas.getContents(),
-    resumen: quillResumen.getContents(),
+async function guardarNota() {
+  const keywords = tinymce.get("editor-keywords").getContent();
+  const notas = tinymce.get("editor-notas").getContent();
+  const resumen = tinymce.get("editor-resumen").getContent();
+  const uea = document.querySelector(".uea").textContent.trim();
+
+  const contenido = {
+    uea,
+    ideas_clave: keywords,
+    notas_principales: notas,
+    resumen,
   };
 
-  // Solo para mostrar el resultado
-  document.getElementById("resultado").textContent = JSON.stringify(
-    quillTodo,
-    null,
-    2
-  );
+  try {
+    const response = await fetch("/api/nota-cornell", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(contenido),
+    });
 
-  // Prueba de guardadok
-  // console.log(quillTodo);
+    if (!response.ok) throw new Error("Error al guardar la nota");
+    alert("Nota guardada correctamente");
+  } catch (err) {
+    alert("Ocurrió un error al guardar: " + err.message);
+  }
 }
 
 async function exportarPDF() {

--- a/client/public/NotaCornell.html
+++ b/client/public/NotaCornell.html
@@ -41,7 +41,7 @@
         </section>
       </div>
       <div class="Botones">
-        <button onclick="Guardar">Guardar</button>
+        <button onclick="guardarNota()">Guardar</button>
         <button onclick="exportarPDF()">Exportar a PDF</button>
       </div>
     </main>

--- a/server/database/db.js
+++ b/server/database/db.js
@@ -1,0 +1,68 @@
+const mysql = require('mysql2/promise');
+const fs = require('fs');
+const path = require('path');
+
+const pool = mysql.createPool({
+  // Using 127.0.0.1 avoids IPv6 issues with localhost
+  host: process.env.DB_HOST || '127.0.0.1',
+  // Default port points to phpMyAdmin/MySQL container
+  port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 8080,
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'dominius',
+  waitForConnections: true,
+  connectionLimit: 10,
+  multipleStatements: true,
+});
+
+async function init() {
+  const sqlPath = path.join(__dirname, 'dominius_estructura.sql');
+  if (fs.existsSync(sqlPath)) {
+    const schema = fs.readFileSync(sqlPath, 'utf8');
+    await pool.query(schema);
+  }
+}
+
+init().catch((err) => console.error('DB init error', err));
+
+async function findOrCreateUser(nombre, correo) {
+  const [rows] = await pool.query('SELECT * FROM usuario WHERE correo = ?', [correo]);
+  if (rows.length) return rows[0];
+  const [result] = await pool.query('INSERT INTO usuario(nombre, correo) VALUES (?, ?)', [nombre, correo]);
+  return { id: result.insertId, nombre, correo };
+}
+
+async function getUserById(id) {
+  const [rows] = await pool.query('SELECT * FROM usuario WHERE id = ?', [id]);
+  return rows[0];
+}
+
+async function findOrCreateUea(nombre) {
+  const [rows] = await pool.query('SELECT * FROM uea WHERE nombre = ?', [nombre]);
+  if (rows.length) return rows[0];
+  const [result] = await pool.query('INSERT INTO uea(nombre) VALUES (?)', [nombre]);
+  return { id: result.insertId, nombre };
+}
+
+async function findOrCreateUsuarioUea(usuarioId, ueaId) {
+  const [rows] = await pool.query('SELECT * FROM usuario_uea WHERE usuario_id = ? AND uea_id = ?', [usuarioId, ueaId]);
+  if (rows.length) return rows[0];
+  const [result] = await pool.query('INSERT INTO usuario_uea(usuario_id, uea_id) VALUES (?, ?)', [usuarioId, ueaId]);
+  return { id: result.insertId, usuario_id: usuarioId, uea_id: ueaId };
+}
+
+async function addNotaCornell(usuarioUeaId, ideas, notas, resumen) {
+  await pool.query(
+    'INSERT INTO nota_cornell(usuario_uea_id, ideas_clave, notas_principales, resumen) VALUES (?, ?, ?, ?)',
+    [usuarioUeaId, ideas, notas, resumen]
+  );
+}
+
+module.exports = {
+  pool,
+  findOrCreateUser,
+  findOrCreateUea,
+  findOrCreateUsuarioUea,
+  addNotaCornell,
+  getUserById,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -858,7 +858,8 @@
     "yaml": "^1.10.2",
     "yargs": "^16.2.0",
     "yargs-parser": "^20.2.9",
-    "yocto-queue": "^0.1.0"
+    "yocto-queue": "^0.1.0",
+    "mysql2": "^3.9.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- switch database module from sqlite3 to mysql2
- seed schema on startup using existing SQL file
- add mysql2 dependency
- configure host/port defaults for phpMyAdmin setup

## Testing
- `npm --prefix server test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68671d9fd10c8325ae6e4c47212e8f4d